### PR TITLE
Make typing stricter and increase readability

### DIFF
--- a/packages/lexical-text/src/index.ts
+++ b/packages/lexical-text/src/index.ts
@@ -16,7 +16,10 @@ import {
   $isParagraphNode,
   $isTextNode,
   TextNode,
+  TextModeType
 } from 'lexical';
+
+import {TEXT_TYPE_TO_MODE} from 'lexical/LexicalConstants'
 
 export type TextNodeWithOffset = {
   node: TextNode;
@@ -163,8 +166,8 @@ export function registerLexicalTextEntity<T extends TextNode>(
     node.replace(textNode);
   };
 
-  const getMode = (node: TextNode): number => {
-    return node.getLatest().__mode;
+  const getMode = (node: TextNode): TextModeType => {
+    return TEXT_TYPE_TO_MODE[node.getLatest().__mode];
   };
 
   const textNodeTransform = (node: TextNode) => {
@@ -183,7 +186,7 @@ export function registerLexicalTextEntity<T extends TextNode>(
       const prevMatch = getMatch(combinedText);
 
       if (isTargetNode(prevSibling)) {
-        if (prevMatch === null || getMode(prevSibling) !== 0) {
+        if (prevMatch === null || getMode(prevSibling) !== 'normal') {
           replaceWithSimpleText(prevSibling);
 
           return;


### PR DESCRIPTION
As I examined this file in order to implement multiple `EntityMatch` objects for my own use case I discovered I wasn't getting very helpful type inference and I also didn't know immediately what  `(prevMatch === null || getMode(prevSibling) !== 0)` wad doing. 

I feel like this will make the file more readable for developers. Let me know if I should be directly importing the constant from somewhere instead of doing `!== 'normal'`. Also I'm not super familiar with the repo so not sure if this will break / fail some tests.